### PR TITLE
Azure: Removing implicit clientId from the set of scopes

### DIFF
--- a/src/azure-provider.tsx
+++ b/src/azure-provider.tsx
@@ -29,7 +29,7 @@ const AzureProvider: React.FC<AzureProviderOptions> = ({
     }}
     client_id={clientId}
     client_secret={clientSecret}
-    scope={getUniqueScopes(scope, clientId, useRefreshTokens ? "offline_access" : "")}
+    scope={getUniqueScopes(scope, useRefreshTokens ? "offline_access" : "")}
     response_type="code"
     loadUserInfo={false}
     automaticSilentRenew={useRefreshTokens}


### PR DESCRIPTION
For AzureAD B2C at least, requesting the clientId as a scope results in an error back from Azure AD B2C, indicating that access tokens from multiple resources are being requested at once.